### PR TITLE
Compatibility fixes

### DIFF
--- a/docs/tutorials/tutorial_3k_tcr.md
+++ b/docs/tutorials/tutorial_3k_tcr.md
@@ -494,5 +494,9 @@ ir.pl.repertoire_overlap(adata, 'sample', dendro_only=True, heatmap_cats=['sourc
 ```
 
 ```python
-ir.pl.repertoire_overlap(adata, 'sample', pair_to_plot=('LN2', 'LT2'))
+ir.pl.repertoire_overlap(adata, 'sample', pair_to_plot=['LN2', 'LT2'])
+```
+
+```python
+
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
 requires-python = '>= 3.6'
 requires = [
     'get_version',
-    'scanpy',
-    # pandas <1 until scanpy is fully compatible...
-    'pandas<1',
+    'anndata>=0.7.1',
+    'scanpy>=1.4.5.post3',
+    'pandas>=0.21',
     'numpy',
     'scipy',
     'parasail',

--- a/scirpy/_plotting/_repertoire_overlap.py
+++ b/scirpy/_plotting/_repertoire_overlap.py
@@ -81,7 +81,11 @@ def repertoire_overlap(
         if heatmap_cats is not None:
             clust_colors, leg_colors = [], []
             for lbl in heatmap_cats:
-                labels = adata.obs.groupby([groupby, lbl]).agg("size").reset_index()
+                labels = (
+                    adata.obs.groupby([groupby, lbl], observed=True)
+                    .agg("size")
+                    .reset_index()
+                )
                 label_levels = labels[lbl].unique()
                 label_pal = sns.cubehelix_palette(
                     label_levels.size,
@@ -153,7 +157,7 @@ def repertoire_overlap(
         if valid_pairs:
             if o_df.shape[1] == 2:
                 o_df = o_df.loc[(o_df.sum(axis=1) != 0), :]
-                o_df = o_df.groupby(pair_to_plot).agg("size")
+                o_df = o_df.groupby(pair_to_plot, observed=True).agg("size")
                 o_df = o_df.reset_index()
                 o_df.columns = ("x", "y", "z")
                 o_df["z"] -= o_df["z"].min()

--- a/scirpy/_tools/_clonal_expansion.py
+++ b/scirpy/_tools/_clonal_expansion.py
@@ -26,7 +26,7 @@ def _clip_and_count(
     groupby = [groupby] if isinstance(groupby, str) else groupby
     groupby_cols = [target_col] if groupby is None else groupby + [target_col]
     clonotype_counts = (
-        adata.obs.groupby(groupby_cols)
+        adata.obs.groupby(groupby_cols, observed=True)
         .size()
         .reset_index(name="tmp_count")
         .assign(

--- a/scirpy/_tools/_clonotypes.py
+++ b/scirpy/_tools/_clonotypes.py
@@ -49,7 +49,7 @@ def _define_clonotypes_no_graph(
     clonotype_col = np.array(
         [
             "clonotype_{}".format(x)
-            for x in adata.obs.groupby(groupby_cols[flavor]).ngroup()
+            for x in adata.obs.groupby(groupby_cols[flavor], observed=True).ngroup()
         ]
     )
     clonotype_col[

--- a/scirpy/_tools/_diversity.py
+++ b/scirpy/_tools/_diversity.py
@@ -52,7 +52,9 @@ def alpha_diversity(
 
     tcr_obs = adata.obs.loc[~_is_na(adata.obs[target_col]), :]
     clono_counts = (
-        tcr_obs.groupby([groupby, target_col]).size().reset_index(name="count")
+        tcr_obs.groupby([groupby, target_col], observed=True)
+        .size()
+        .reset_index(name="count")
     )
 
     diversity = dict()

--- a/scirpy/_tools/_group_abundance.py
+++ b/scirpy/_tools/_group_abundance.py
@@ -26,7 +26,8 @@ def _group_abundance(
     # Calculate distribution of lengths in each group. Use sum instead of count
     # to reflect weights
     group_counts = (
-        tcr_obs.groupby([groupby, target_col])["count", "weight"]
+        tcr_obs.loc[:, [groupby, target_col, "count", "weight"]]
+        .groupby([groupby, target_col], observed=True)
         .sum()
         .reset_index()
         .rename(columns={"weight": "weighted_count"})

--- a/scirpy/_tools/_group_abundance.py
+++ b/scirpy/_tools/_group_abundance.py
@@ -26,7 +26,8 @@ def _group_abundance(
     # Calculate distribution of lengths in each group. Use sum instead of count
     # to reflect weights
     group_counts = (
-        tcr_obs.groupby([groupby, target_col])["count", "weight"]
+        tcr_obs.groupby([groupby, target_col])
+        .loc[:, ["count", "weight"]]
         .sum()
         .reset_index()
         .rename(columns={"weight": "weighted_count"})

--- a/scirpy/_tools/_group_abundance.py
+++ b/scirpy/_tools/_group_abundance.py
@@ -26,8 +26,7 @@ def _group_abundance(
     # Calculate distribution of lengths in each group. Use sum instead of count
     # to reflect weights
     group_counts = (
-        tcr_obs.groupby([groupby, target_col])
-        .loc[:, ["count", "weight"]]
+        tcr_obs.groupby([groupby, target_col])["count", "weight"]
         .sum()
         .reset_index()
         .rename(columns={"weight": "weighted_count"})

--- a/scirpy/_tools/_repertoire_overlap.py
+++ b/scirpy/_tools/_repertoire_overlap.py
@@ -63,7 +63,11 @@ def repertoire_overlap(
     )
 
     # Create a weighted matrix of clonotypes
-    df = df.groupby([target_col, groupby]).agg({"cell_weights": "sum"}).reset_index()
+    df = (
+        df.groupby([target_col, groupby], observed=True)
+        .agg({"cell_weights": "sum"})
+        .reset_index()
+    )
     df = df.pivot(index=groupby, columns=target_col, values="cell_weights")
     df = df.fillna(0)
 


### PR DESCRIPTION
- alpha diversity had an issue with pandas > 1
- minimal version requirements for anndata and scanpy are now implemented (#111)
- fixed pandas future warning in `group_abundance`
- use `groupby(observed=True)` wherever applicable. 