### PR TITLE
Adapt tcr_dist to support second array of sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ test = [
     'black'
 ]
 doc = [
-    'sphinx>=3.0.1',
+    'sphinx>=3.0.1,<3.1',
     'sphinx_autodoc_typehints>=1.8.0',
     'sphinx_rtd_theme>=0.4',
     'scanpydoc>=0.4.5',


### PR DESCRIPTION
Closes #165.

Before, tcr_dist could only compute a square distance matrix.
However, it can be useful to compute the distance against
another array of sequences, e.g. a CDR3 reference database.

This PR enables tcr_dist to compute a rectangular seqs1 x seqs2
distance matrix in addition to the square distance matrix.