### PR TITLE
Improve packaging

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,27 +16,9 @@ build:
 
 requirements:
   # The way the version is resolved from SCM (flit + get_version)
-  # requires all dependencies to be installed at build time. 
-  host:
-    - python >=3.6
-    - flit
-    - get_version
-    - anndata >=0.7.3
-    - scanpy>=1.5.1
-    - pandas>=0.21
-    - numpy=1.18
-    - scipy
-    - parasail-python
-    - scikit-learn
-    - python-levenshtein
-    - python-igraph
-    - networkx
-    - squarify
-    - tqdm>=4.29.1
-    - airr>=1.2
+  # requires all dependencies to be installed at build time.
   run:
     - python >=3.6
-    - get_version
     - anndata >=0.7.3
     - scanpy>=1.5.1
     - pandas>=0.21
@@ -71,11 +53,11 @@ test:
 
 about:
   home: https://icbi-lab.github.io/scirpy
-  dev_url: https://github.com/icbi-lab/scirpy 
+  dev_url: https://github.com/icbi-lab/scirpy
   license: BSD-3
   license_family: BSD
-  summary: A Scanpy extension for analyzing single-cell T-cell receptor sequencing data.  
+  summary: A Scanpy extension for analyzing single-cell T-cell receptor sequencing data.
 
 extra:
   identifiers:
-   - doi:10.1101/2020.04.10.035865  
+   - doi:10.1101/2020.04.10.035865

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,6 +17,13 @@ build:
 requirements:
   # The way the version is resolved from SCM (flit + get_version)
   # requires all dependencies to be installed at build time.
+  host:
+    - python >=3.6
+    - flit
+    - setuptools_scm
+    - pytoml
+    - importlib_metadata
+
   run:
     - python >=3.6
     - anndata >=0.7.3

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 88
+
+[*.py]
+indent_size = 4
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ max_line_length = 88
 [*.py]
 indent_size = 4
 indent_style = space
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: [3.6, 3.7, 3.8]
         os: ["ubuntu-latest", "macos-latest"]
 
     steps:
@@ -36,5 +37,5 @@ jobs:
       - name: build and test package
         run: |
           cd .conda
-          conda build . --no-anaconda-upload
+          conda build . --no-anaconda-upload --python ${{ matrix.python-version }}
         shell: bash

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
@@ -14,15 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-    
+
     steps:
       - uses: actions/checkout@v2
-        
-      - name: Setup Minoconda 
+        with:
+          fetch-depth: 0 # required for setuptools-scm
+
+      - name: Setup Minoconda
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true
-      
+
       - name: Set-up channels and install conda build
         run: |
           conda config --add channels defaults
@@ -30,7 +32,7 @@ jobs:
           conda config --add channels conda-forge
           conda install -y conda-build conda-verify
         shell: bash
-          
+
       - name: build and test package
         run: |
           cd .conda

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    name: conda ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +24,7 @@ jobs:
         uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
 
       - name: Set-up channels and install conda build
         run: |
@@ -37,5 +37,5 @@ jobs:
       - name: build and test package
         run: |
           cd .conda
-          conda build . --no-anaconda-upload --python ${{ matrix.python-version }}
+          conda build --no-anaconda-upload .
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # required for setuptools-scm
       - name: Fetch all tags s.t. get_version can retrieve the correct version.
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
@@ -64,11 +66,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install flit
-          flit install --deps develop
-        env:
-          FLIT_ROOT_INSTALL: 1
-
+          pip install .[doc,test,rpack]
       - name: run sphinx
         run: |
           cd docs && make html SPHINXOPTS="-W --keep-going"
@@ -101,3 +99,4 @@ jobs:
           TARGET_FOLDER: ${{ env.target_dir }}
           CLEAN: true
           CLEAN_EXCLUDE: '["heads", "pull", "tags"]'
+          SINGLE_COMMIT: true

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,23 +6,24 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install flit
-        flit install
-    - name: Build and publish
-      env:
-        FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        flit build
-        flit publish
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # required for setuptools-scm
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install flit
+          flit install
+      - name: Build and publish
+        env:
+          FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          flit build
+          flit publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # required for setuptools-scm
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
@@ -43,10 +45,7 @@ jobs:
           pip install $pkg
       - name: Install dependencies
         run: |
-          python -m pip install flit
-          flit install --deps all
-        env:
-          FLIT_ROOT_INSTALL: 1
+          pip install .[test,rpack]
       - name: Check black formatting
         run: |
           black --check scirpy tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.code-workspace
 .vscode/*
 !.vscode/settings.json.default
 notebooks

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ help:
 
 .PHONY: help Makefile
 
-livehtml: | clean
+livehtml: | clean symlink
 	sleep 1 && touch *.rst
 	sphinx-autobuild \
 	-p 0 \
@@ -32,7 +32,15 @@ livehtml: | clean
         --ignore "*.tex" \
 	-b html $(SOURCEDIR) $(BUILDDIR)/html
 
-clean: 
+html: | symlink
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+symlink:
+	mkdir -p generated
+	# link static to the generated directory, s.t. relative links keep working.
+	ln -sn ../_static generated/_static || true
+
+clean:
 	rm -rf generated
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -36,9 +36,9 @@ html: | symlink
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 symlink:
-	mkdir -p generated
+	mkdir -p _build/html/generated
 	# link static to the generated directory, s.t. relative links keep working.
-	ln -sn ../_static generated/_static || true
+	ln -sn ../_static _build/html/generated/_static || true
 
 clean:
 	rm -rf generated

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ nbsphinx_timeout = 300
 
 # -- HTML styling ----------------------------------------------------------------------
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "scanpydoc"
 # add custom stylesheet
 # https://stackoverflow.com/a/43186995/2340703
 html_static_path = ["_static"]
@@ -110,7 +110,7 @@ html_theme_options = dict(navigation_depth=4, logo_only=True)
 
 
 def setup(app):
-    app.add_css_file("custom.css")
+    pass
 
 
 # -- Supress 'reference target not found' errors ---------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ test = [
 doc = [
     'sphinx>=3.0.1,<3.1',
     'sphinx_autodoc_typehints>=1.8.0',
-    'sphinx_rtd_theme>=0.4',
     'scanpydoc>=0.5',
+    'sphinx_rtd_theme>=0.4',
     'typing_extensions; python_version < "3.8"',  # for `Literal`
     # for tutorial
     'leidenalg',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [build-system]
-requires = ['flit']
-build-backend = 'flit.buildapi'
+requires = [
+    'flit_core >=2,<4', 
+    'setuptools_scm',
+    'pytoml', 
+    'importlib_metadata>=0.7; python_version < "3.8"'
+]
+build-backend = 'flit_core.buildapi'
 
 [tool.flit.metadata]
 module = 'scirpy'
-author = 'Gregor Sturm'
+author = 'Gregor Sturm, Tamas Szabo'
 author-email = 'gregor.sturm@i-med.ac.at'
 home-page = 'https://github.com/grst/scirpy'
 description-file = "README.rst"
@@ -18,7 +23,6 @@ classifiers = [
 ]
 requires-python = '>= 3.6'
 requires = [
-    'get_version',
     'anndata>=0.7.3',
     'scanpy>=1.5.1',
     'pandas>=0.21',
@@ -31,7 +35,11 @@ requires = [
     'networkx',
     'squarify',
     'airr',
-    'tqdm>=4.29.1' # See https://github.com/icbi-lab/scirpy/issues/128#issuecomment-632646608
+    'tqdm>=4.29.1', # See https://github.com/icbi-lab/scirpy/issues/128#issuecomment-632646608
+    # for getting the version
+    'setuptools_scm',
+    'pytoml', 
+    'importlib_metadata>=0.7; python_version < "3.8"'
 ]
 
 [tool.flit.metadata.requires-extra]
@@ -46,7 +54,7 @@ doc = [
     'sphinx>=3.0.1,<3.1',
     'sphinx_autodoc_typehints>=1.8.0',
     'sphinx_rtd_theme>=0.4',
-    'scanpydoc>=0.4.5',
+    'scanpydoc>=0.5',
     'typing_extensions; python_version < "3.8"',  # for `Literal`
     # for tutorial
     'leidenalg',
@@ -57,3 +65,6 @@ doc = [
     'jupyter_client',
     'ipykernel',
 ]
+
+[tool.flit.metadata.urls]
+Documentation = 'https://icbi-lab.github.io/scirpy/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
-    'flit_core >=2,<4', 
+    'flit_core >=2,<4',
     'setuptools_scm',
-    'pytoml', 
+    'pytoml',
+    'wheel',
     'importlib_metadata>=0.7; python_version < "3.8"'
 ]
 build-backend = 'flit_core.buildapi'
@@ -38,12 +39,12 @@ requires = [
     'tqdm>=4.29.1', # See https://github.com/icbi-lab/scirpy/issues/128#issuecomment-632646608
     # for getting the version
     'setuptools_scm',
-    'pytoml', 
+    'pytoml',
     'importlib_metadata>=0.7; python_version < "3.8"'
 ]
 
 [tool.flit.metadata.requires-extra]
-optional = [
+rpack = [
     'rectangle-packer',
 ]
 test = [

--- a/scirpy/__init__.py
+++ b/scirpy/__init__.py
@@ -1,15 +1,12 @@
 """Python library for single-cell TCR analysis"""
-from get_version import get_version
 
-__version__ = get_version(__file__)
-del get_version
+from ._metadata import __version__, __author__, __email__, within_flit
 
-__author__ = ", ".join(["Gregor Sturm", "Tamas Szabo"])
-
-from scanpy import AnnData, read_h5ad
-from . import io
-from . import util
-from . import _preprocessing as pp
-from . import _tools as tl
-from . import _plotting as pl
-from . import datasets
+if not within_flit():
+    from scanpy import AnnData, read_h5ad
+    from . import io
+    from . import util
+    from . import _preprocessing as pp
+    from . import _tools as tl
+    from . import _plotting as pl
+    from . import datasets

--- a/scirpy/_compat.py
+++ b/scirpy/_compat.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 try:
     from typing import Literal
 except ImportError:

--- a/scirpy/_compat.py
+++ b/scirpy/_compat.py
@@ -13,3 +13,19 @@ except ImportError:
 
         class Literal(metaclass=LiteralMeta):
             pass
+
+
+def pkg_metadata(package):
+    try:
+        from importlib.metadata import metadata as m
+    except ImportError:  # < Python 3.8: Use backport module
+        from importlib_metadata import metadata as m
+    return m(package)
+
+
+def pkg_version(package):
+    try:
+        from importlib.metadata import version as v
+    except ImportError:  # < Python 3.8: Use backport module
+        from importlib_metadata import version as v
+    return version.parse(v(package))

--- a/scirpy/_metadata.py
+++ b/scirpy/_metadata.py
@@ -14,7 +14,8 @@ try:
     __version__ = get_version(root="..", relative_to=__file__)
     __author__ = metadata["author"]
     __email__ = metadata["author-email"]
-except (LookupError, FileNotFoundError):
+
+except (ImportError, LookupError, FileNotFoundError):
     from ._compat import pkg_metadata
 
     metadata = pkg_metadata(here.name)

--- a/scirpy/_metadata.py
+++ b/scirpy/_metadata.py
@@ -1,0 +1,30 @@
+"""Metadata. Adapted from https://github.com/theislab/scanpy/pull/1374/."""
+import traceback
+from pathlib import Path
+
+here = Path(__file__).parent
+
+try:
+    from setuptools_scm import get_version
+    import pytoml
+
+    proj = pytoml.loads((here.parent / "pyproject.toml").read_text())
+    metadata = proj["tool"]["flit"]["metadata"]
+
+    __version__ = get_version(root="..", relative_to=__file__)
+    __author__ = metadata["author"]
+    __email__ = metadata["author-email"]
+except (LookupError, FileNotFoundError):
+    from ._compat import pkg_metadata
+
+    metadata = pkg_metadata(here.name)
+    __version__ = metadata["Version"]
+    __author__ = metadata["Author"]
+    __email__ = metadata["Author-email"]
+
+
+def within_flit():
+    for frame in traceback.extract_stack():
+        if frame.name == "get_docstring_and_version_via_import":
+            return True
+    return False

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,8 +1,0 @@
-{
-  "folders": [
-    {
-      "path": "."
-    }
-  ],
-  "settings": {}
-}


### PR DESCRIPTION
Closes #178 

1) Switch from `get_version` to `setuptools_scm` which is more stable
2) Implement the changes `@ flyingsheep` proposed for scanpy
   (https://github.com/theislab/scanpy/pull/1374/,
   https://github.com/theislab/scanpy/pull/1376/). This cleans up some
   redundancies and imports the package dependencies only
   at run time, not at build time.