### PR TITLE
Only run release action on vX.X.X tags

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,8 +1,9 @@
 name: Publish on PyPI
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   deploy:


### PR DESCRIPTION
This allows me to create data releases independent of the versioned releases