### PR TITLE
Immunologist-approved BCR similarity measure implementation attempt

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -21,21 +21,21 @@ jobs:
           fetch-depth: 0 # required for setuptools-scm
 
       - name: Setup Minoconda
-        uses: goanpeca/setup-miniconda@v1
+        uses: goanpeca/setup-miniconda@v2
         with:
           auto-update-conda: true
+          mamba-version: "*"
+          channels: conda-forge,bioconda,defaults
+          channel-priority: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Set-up channels and install conda build
+      - name: install conda build
         run: |
-          conda config --add channels defaults
-          conda config --add channels bioconda
-          conda config --add channels conda-forge
-          conda install -y conda-build conda-verify
+          mamba install -y conda-build conda-verify
         shell: bash
 
       - name: build and test package
         run: |
           cd .conda
-          conda build --no-anaconda-upload .
+          mamba build --no-anaconda-upload .
         shell: bash

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           fetch-depth: 0 # required for setuptools-scm
 
-      - name: Setup Minoconda
-        uses: goanpeca/setup-miniconda@v1
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           mamba-version: "*"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0 # required for setuptools-scm
 
       - name: Setup Minoconda
-        uses: goanpeca/setup-miniconda@v2
+        uses: goanpeca/setup-miniconda@v1
         with:
           auto-update-conda: true
           mamba-version: "*"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,7 +82,7 @@ jobs:
         if: ( matrix.os == 'ubuntu-latest' ) &&  ( matrix.python-version == '3.7' )
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/_build/html # The folder the action should deploy.
           TARGET_FOLDER: ${{ env.target_dir }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,7 +74,7 @@ jobs:
           # when on master, we want to deploy to the root dir (-> ".")
           target_dir=$(echo $tmp_target_dir | sed "s/heads\/master/./")
           echo $target_dir
-          echo "::set-env name=target_dir::$target_dir"
+          echo "target_dir=$target_dir" >> $GITHUB_ENV
         env:
           github_ref: ${{ github.ref }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,7 +82,7 @@ jobs:
         if: ( matrix.os == 'ubuntu-latest' ) &&  ( matrix.python-version == '3.7' )
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/_build/html # The folder the action should deploy.
           TARGET_FOLDER: ${{ env.target_dir }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,3 +89,4 @@ jobs:
           CLEAN: true
           CLEAN_EXCLUDE: '["heads", "pull", "tags"]'
           SINGLE_COMMIT: true
+          REPOSITORY_NAME: icbi-lab/scirpy

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -207,5 +207,6 @@ IR distance metrics: `ir_dist`
    ParallelDistanceCalculator
    IdentityDistanceCalculator
    LevenshteinDistanceCalculator
+   HammingSubstitutionDistanceCalculator
    AlignmentDistanceCalculator
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -207,6 +207,6 @@ IR distance metrics: `ir_dist`
    ParallelDistanceCalculator
    IdentityDistanceCalculator
    LevenshteinDistanceCalculator
-   HammingSubstitutionDistanceCalculator
+   HammingDistanceCalculator
    AlignmentDistanceCalculator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ requires = [
     'numpy',
     'scipy',
     # parasail 1.2.1 fails to be installd on MacOS
-    'parasail',
-    'parasail != 1.2.1; sys_platform == "darwin"',
+    'parasail != 1.2.1',
     'scikit-learn',
     'python-levenshtein',
     'python-igraph',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ requires = [
     'pandas>=0.21',
     'numpy',
     'scipy',
+    # mandate wheel package for parasail until https://github.com/jeffdaily/parasail-python/issues/55 gets resolved.
+    'wheel',
     'parasail',
     'scikit-learn',
     'python-levenshtein',
@@ -41,7 +43,7 @@ requires = [
     'setuptools_scm',
     'pytoml',
     'importlib_metadata>=0.7; python_version < "3.8"',
-    'pycairo>=1.20; sys_platform == "win32"'
+    'pycairo>=1.20; sys_platform == "win32"',
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ requires = [
     'pandas>=0.21',
     'numpy',
     'scipy',
-    # mandate wheel package for parasail until https://github.com/jeffdaily/parasail-python/issues/55 gets resolved.
-    'wheel',
+    # parasail 1.2.1 fails to be installd on MacOS
     'parasail',
+    'parasail != 1.2.1; sys_platform == "darwin"',
     'scikit-learn',
     'python-levenshtein',
     'python-igraph',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,6 @@ doc = [
     'pycairo',
     'jupyter_client',
     'ipykernel',
-    # ipyernel fails on macos if this is not installed.
-    'appnope; sys_platform == "darwin"'
 ]
 
 [tool.flit.metadata.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ doc = [
     'pycairo',
     'jupyter_client',
     'ipykernel',
+    # ipyernel fails on macos if this is not installed.
+    'appnope; sys_platform == "darwin"'
 ]
 
 [tool.flit.metadata.urls]

--- a/scirpy/_tools/_clonotypes.py
+++ b/scirpy/_tools/_clonotypes.py
@@ -63,7 +63,9 @@ def define_clonotype_clusters(
     adata: AnnData,
     *,
     sequence: Literal["aa", "nt"] = "aa",
-    metric: Literal["alignment", "levenshtein", "hamming-substitution", "identity"] = "identity",
+    metric: Literal[
+        "alignment", "levenshtein", "hamming-substitution", "identity"
+    ] = "identity",
     key_added: Union[str, None] = None,
     **kwargs,
 ) -> Union[Tuple[np.ndarray, np.ndarray], None]:
@@ -214,7 +216,9 @@ def clonotype_network(
     adata: AnnData,
     *,
     sequence: Literal["aa", "nt"] = "nt",
-    metric: Literal["identity", "alignment", "levenshtein", "hamming-substitution", "custom"] = "identity",
+    metric: Literal[
+        "identity", "alignment", "levenshtein", "hamming-substitution", "custom"
+    ] = "identity",
     min_size: int = 1,
     layout: str = "components",
     layout_kwargs: Union[dict, None] = None,

--- a/scirpy/_tools/_clonotypes.py
+++ b/scirpy/_tools/_clonotypes.py
@@ -63,9 +63,7 @@ def define_clonotype_clusters(
     adata: AnnData,
     *,
     sequence: Literal["aa", "nt"] = "aa",
-    metric: Literal[
-        "alignment", "levenshtein", "hamming-substitution", "identity"
-    ] = "identity",
+    metric: Literal["alignment", "levenshtein", "hamming", "identity"] = "identity",
     key_added: Union[str, None] = None,
     **kwargs,
 ) -> Union[Tuple[np.ndarray, np.ndarray], None]:
@@ -217,7 +215,7 @@ def clonotype_network(
     *,
     sequence: Literal["aa", "nt"] = "nt",
     metric: Literal[
-        "identity", "alignment", "levenshtein", "hamming-substitution", "custom"
+        "identity", "alignment", "levenshtein", "hamming", "custom"
     ] = "identity",
     min_size: int = 1,
     layout: str = "components",

--- a/scirpy/_tools/_clonotypes.py
+++ b/scirpy/_tools/_clonotypes.py
@@ -63,7 +63,7 @@ def define_clonotype_clusters(
     adata: AnnData,
     *,
     sequence: Literal["aa", "nt"] = "aa",
-    metric: Literal["alignment", "levenshtein", "identity"] = "identity",
+    metric: Literal["alignment", "levenshtein", "hamming-substitution", "identity"] = "identity",
     key_added: Union[str, None] = None,
     **kwargs,
 ) -> Union[Tuple[np.ndarray, np.ndarray], None]:
@@ -214,7 +214,7 @@ def clonotype_network(
     adata: AnnData,
     *,
     sequence: Literal["aa", "nt"] = "nt",
-    metric: Literal["identity", "alignment", "levenshtein", "custom"] = "identity",
+    metric: Literal["identity", "alignment", "levenshtein", "hamming-substitution", "custom"] = "identity",
     min_size: int = 1,
     layout: str = "components",
     layout_kwargs: Union[dict, None] = None,

--- a/scirpy/ir_dist/__init__.py
+++ b/scirpy/ir_dist/__init__.py
@@ -9,7 +9,7 @@ from scanpy import logging
 from ..util import _is_na, deprecated
 import abc
 from Levenshtein import distance as levenshtein_dist
-from scipy.spatial.distance import hamming as hamming_dist
+from Levenshtein import hamming as hamming_dist
 import scipy.spatial
 import scipy.sparse
 from scipy.sparse import coo_matrix, csr_matrix
@@ -340,7 +340,7 @@ class HammingSubstitutionDistanceCalculator(ParallelDistanceCalculator):
 
     The edit distance is the total number of substitution events.
 
-    This class relies on `scipy <https://github.com/scipy/scipy>`_
+    This class relies on `Python-levenshtein <https://github.com/ztane/python-Levenshtein>`_
     to calculate the distances.
 
     Choosing a cutoff:

--- a/scirpy/ir_dist/__init__.py
+++ b/scirpy/ir_dist/__init__.py
@@ -333,6 +333,7 @@ class LevenshteinDistanceCalculator(ParallelDistanceCalculator):
 
         return result
 
+
 @_doc_params(params=_doc_params_parallel_distance_calculator)
 class HammingSubstitutionDistanceCalculator(ParallelDistanceCalculator):
     """\
@@ -495,7 +496,8 @@ def sequence_dist(
     unique_seqs2: Union[None, np.ndarray] = None,
     *,
     metric: Union[
-        Literal["alignment", "identity", "levenshtein", "hamming-substitution"], DistanceCalculator
+        Literal["alignment", "identity", "levenshtein", "hamming-substitution"],
+        DistanceCalculator,
     ] = "identity",
     cutoff: float = 10,
     n_jobs: Union[int, None] = None,
@@ -559,7 +561,8 @@ class IrNeighbors:
         adata: AnnData,
         *,
         metric: Union[
-            Literal["alignment", "identity", "levenshtein", "hamming-substitution"], DistanceCalculator
+            Literal["alignment", "identity", "levenshtein", "hamming-substitution"],
+            DistanceCalculator,
         ] = "identity",
         cutoff: float = 10,
         receptor_arms: Literal["VJ", "VDJ", "all", "any"] = "all",
@@ -934,7 +937,8 @@ def ir_neighbors(
     adata: AnnData,
     *,
     metric: Union[
-        Literal["identity", "alignment", "levenshtein", "hamming-substitution"], DistanceCalculator
+        Literal["identity", "alignment", "levenshtein", "hamming-substitution"],
+        DistanceCalculator,
     ] = "identity",
     cutoff: int = 10,
     receptor_arms: Literal["VJ", "VDJ", "all", "any"] = "all",

--- a/scirpy/ir_dist/__init__.py
+++ b/scirpy/ir_dist/__init__.py
@@ -339,7 +339,10 @@ class HammingDistanceCalculator(ParallelDistanceCalculator):
     """\
     Calculates the Hamming distance between sequences of identical length.
 
-    The edit distance is the total number of substitution events.
+    The edit distance is the total number of substitution events. Sequences
+    with different lengths will be treated as though they exceeded the
+    distance-cutoff, i.e. they receive a distance of `0` in the sparse distance
+    matrix and will not be connected by an edge in the graph.
 
     This class relies on `Python-levenshtein <https://github.com/ztane/python-Levenshtein>`_
     to calculate the distances.

--- a/scirpy/ir_dist/__init__.py
+++ b/scirpy/ir_dist/__init__.py
@@ -9,6 +9,7 @@ from scanpy import logging
 from ..util import _is_na, deprecated
 import abc
 from Levenshtein import distance as levenshtein_dist
+from scipy.spatial.distance import hamming as hamming_dist
 import scipy.spatial
 import scipy.sparse
 from scipy.sparse import coo_matrix, csr_matrix
@@ -23,6 +24,8 @@ metric
         This metric implies a cutoff of 0.
       * `levenshtein` -- Levenshtein edit distance.
         See :class:`~scirpy.ir_dist.LevenshteinDistanceCalculator`.
+      * `hamming-substitution` -- Hamming distance for CDR3 sequences of equal length.
+        See :class:`~scirpy.ir_dist.HammingSubstitutionDistanceCalculator`.
       * `alignment` -- Distance based on pairwise sequence alignments using the
         BLOSUM62 matrix. This option is incompatible with nucleotide sequences.
         See :class:`~scirpy.ir_dist.AlignmentDistanceCalculator`.
@@ -330,6 +333,49 @@ class LevenshteinDistanceCalculator(ParallelDistanceCalculator):
 
         return result
 
+@_doc_params(params=_doc_params_parallel_distance_calculator)
+class HammingSubstitutionDistanceCalculator(ParallelDistanceCalculator):
+    """\
+    Calculates the Hamming distance between sequences of identical length.
+
+    The edit distance is the total number of substitution events.
+
+    This class relies on `scipy <https://github.com/scipy/scipy>`_
+    to calculate the distances.
+
+    Choosing a cutoff:
+        Each modification stands for a substitution event.
+        While lacking empirical data, it seems unlikely that CDR3 sequences with more
+        than two modifications still recognize the same antigen.
+
+    Parameters
+    ----------
+    {params}
+    """
+
+    def _compute_block(self, seqs1, seqs2, origin):
+        origin_row, origin_col = origin
+        if seqs2 is not None:
+            # compute the full matrix
+            coord_iterator = itertools.product(enumerate(seqs1), enumerate(seqs2))
+        else:
+            # compute only upper triangle in this case
+            coord_iterator = itertools.combinations_with_replacement(
+                enumerate(seqs1), r=2
+            )
+
+        result = []
+        for (row, s1), (col, s2) in coord_iterator:
+
+            # require identical length of sequences
+            if len(s1) != len(s2):
+                continue
+            d = hamming_dist(s1, s2)
+            if d <= self.cutoff:
+                result.append((d + 1, origin_row + row, origin_col + col))
+
+        return result
+
 
 @_doc_params(params=_doc_params_parallel_distance_calculator)
 class AlignmentDistanceCalculator(ParallelDistanceCalculator):
@@ -449,7 +495,7 @@ def sequence_dist(
     unique_seqs2: Union[None, np.ndarray] = None,
     *,
     metric: Union[
-        Literal["alignment", "identity", "levenshtein"], DistanceCalculator
+        Literal["alignment", "identity", "levenshtein", "hamming-substitution"], DistanceCalculator
     ] = "identity",
     cutoff: float = 10,
     n_jobs: Union[int, None] = None,
@@ -490,6 +536,8 @@ def sequence_dist(
         dist_calc = IdentityDistanceCalculator(cutoff=cutoff)
     elif metric == "levenshtein":
         dist_calc = LevenshteinDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs)
+    elif metric == "hamming-substitution":
+        dist_calc = HammingSubstitutionDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs)
     else:
         raise ValueError("Invalid distance metric.")
 
@@ -511,7 +559,7 @@ class IrNeighbors:
         adata: AnnData,
         *,
         metric: Union[
-            Literal["alignment", "identity", "levenshtein"], DistanceCalculator
+            Literal["alignment", "identity", "levenshtein", "hamming-substitution"], DistanceCalculator
         ] = "identity",
         cutoff: float = 10,
         receptor_arms: Literal["VJ", "VDJ", "all", "any"] = "all",
@@ -824,7 +872,7 @@ class IrNeighbors:
         Parameters
         ----------
         n_jobs
-            Number of CPUs to use for alignment and levenshtein distance.
+            Number of CPUs to use for alignment, levenshtein or hamming-substitution distance.
             Default: use all CPUS.
         """
         for arm, arm_dict in self.index_dict.items():
@@ -886,7 +934,7 @@ def ir_neighbors(
     adata: AnnData,
     *,
     metric: Union[
-        Literal["identity", "alignment", "levenshtein"], DistanceCalculator
+        Literal["identity", "alignment", "levenshtein", "hamming-substitution"], DistanceCalculator
     ] = "identity",
     cutoff: int = 10,
     receptor_arms: Literal["VJ", "VDJ", "all", "any"] = "all",
@@ -939,7 +987,7 @@ def ir_neighbors(
         If `True`, store the results in `adata.uns`. Otherwise return
         the results.
     n_jobs:
-        Number of cores to use for alignment and levenshtein distance.
+        Number of cores to use for alignment, levenshtein or hamming-substitution distance.
 
     Returns
     -------

--- a/scirpy/ir_dist/__init__.py
+++ b/scirpy/ir_dist/__init__.py
@@ -24,8 +24,8 @@ metric
         This metric implies a cutoff of 0.
       * `levenshtein` -- Levenshtein edit distance.
         See :class:`~scirpy.ir_dist.LevenshteinDistanceCalculator`.
-      * `hamming-substitution` -- Hamming distance for CDR3 sequences of equal length.
-        See :class:`~scirpy.ir_dist.HammingSubstitutionDistanceCalculator`.
+      * `hamming` -- Hamming distance for CDR3 sequences of equal length.
+        See :class:`~scirpy.ir_dist.HammingDistanceCalculator`.
       * `alignment` -- Distance based on pairwise sequence alignments using the
         BLOSUM62 matrix. This option is incompatible with nucleotide sequences.
         See :class:`~scirpy.ir_dist.AlignmentDistanceCalculator`.
@@ -335,7 +335,7 @@ class LevenshteinDistanceCalculator(ParallelDistanceCalculator):
 
 
 @_doc_params(params=_doc_params_parallel_distance_calculator)
-class HammingSubstitutionDistanceCalculator(ParallelDistanceCalculator):
+class HammingDistanceCalculator(ParallelDistanceCalculator):
     """\
     Calculates the Hamming distance between sequences of identical length.
 
@@ -496,7 +496,7 @@ def sequence_dist(
     unique_seqs2: Union[None, np.ndarray] = None,
     *,
     metric: Union[
-        Literal["alignment", "identity", "levenshtein", "hamming-substitution"],
+        Literal["alignment", "identity", "levenshtein", "hamming"],
         DistanceCalculator,
     ] = "identity",
     cutoff: float = 10,
@@ -538,8 +538,8 @@ def sequence_dist(
         dist_calc = IdentityDistanceCalculator(cutoff=cutoff)
     elif metric == "levenshtein":
         dist_calc = LevenshteinDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs)
-    elif metric == "hamming-substitution":
-        dist_calc = HammingSubstitutionDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs)
+    elif metric == "hamming":
+        dist_calc = HammingDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs)
     else:
         raise ValueError("Invalid distance metric.")
 
@@ -561,7 +561,7 @@ class IrNeighbors:
         adata: AnnData,
         *,
         metric: Union[
-            Literal["alignment", "identity", "levenshtein", "hamming-substitution"],
+            Literal["alignment", "identity", "levenshtein", "hamming"],
             DistanceCalculator,
         ] = "identity",
         cutoff: float = 10,
@@ -875,7 +875,7 @@ class IrNeighbors:
         Parameters
         ----------
         n_jobs
-            Number of CPUs to use for alignment, levenshtein or hamming-substitution distance.
+            Number of CPUs to use for alignment, levenshtein or hamming distance.
             Default: use all CPUS.
         """
         for arm, arm_dict in self.index_dict.items():
@@ -937,7 +937,7 @@ def ir_neighbors(
     adata: AnnData,
     *,
     metric: Union[
-        Literal["identity", "alignment", "levenshtein", "hamming-substitution"],
+        Literal["identity", "alignment", "levenshtein", "hamming"],
         DistanceCalculator,
     ] = "identity",
     cutoff: int = 10,
@@ -991,7 +991,7 @@ def ir_neighbors(
         If `True`, store the results in `adata.uns`. Otherwise return
         the results.
     n_jobs:
-        Number of cores to use for alignment, levenshtein or hamming-substitution distance.
+        Number of cores to use for alignment, levenshtein or hamming distance.
 
     Returns
     -------

--- a/scirpy/tests/test_tcr_dist.py
+++ b/scirpy/tests/test_tcr_dist.py
@@ -4,7 +4,7 @@ from scirpy.ir_dist import (
     DistanceCalculator,
     IdentityDistanceCalculator,
     LevenshteinDistanceCalculator,
-    HammingSubstitutionDistanceCalculator,
+    HammingDistanceCalculator,
     ParallelDistanceCalculator,
     IrNeighbors,
 )
@@ -174,7 +174,7 @@ def test_levensthein_dist_with_two_seq_arrays():
 
 
 def test_hamming_dist():
-    hamming10 = HammingSubstitutionDistanceCalculator(2)
+    hamming10 = HammingDistanceCalculator(2)
     res = hamming10.calc_dist_mat(
         np.array(["A", "AA", "AAA", "AAR", "ZZZZZZ"]), np.array(["RRR", "AR"])
     )

--- a/scirpy/tests/test_tcr_dist.py
+++ b/scirpy/tests/test_tcr_dist.py
@@ -4,6 +4,7 @@ from scirpy.ir_dist import (
     DistanceCalculator,
     IdentityDistanceCalculator,
     LevenshteinDistanceCalculator,
+    HammingSubstitutionDistanceCalculator,
     ParallelDistanceCalculator,
     IrNeighbors,
 )
@@ -169,6 +170,19 @@ def test_levensthein_dist_with_two_seq_arrays():
     npt.assert_almost_equal(
         res.toarray(),
         np.array([[0, 2], [0, 2], [0, 3], [3, 2], [0, 0]]),
+    )
+
+
+def test_hamming_dist():
+    hamming10 = HammingSubstitutionDistanceCalculator(2)
+    res = hamming10.calc_dist_mat(
+        np.array(["A", "AA", "AAA", "AAR", "ZZZZZZ"]), np.array(["RRR", "AR"])
+    )
+    assert isinstance(res, scipy.sparse.coo_matrix)
+    assert res.shape == (5, 2)
+    npt.assert_almost_equal(
+        res.toarray(),
+        np.array([[0, 0], [0, 2], [0, 0], [3, 0], [0, 0]]),
     )
 
 


### PR DESCRIPTION
Figured that rather than make an issue asking for a thing I'd tried to implement the thing myself, to mixed results.

I have consulted with an immunologist with regards to BCR clonotype calling, and apparently somatic hypermutation only leads to substitution events. As such, an appropriate way to identify neighbours would be to require sequence length compatibility, and then use Hamming distance to identify substitutions. Going into your source code, the logic for the Levenshtein distance was clear:

        result = []
        for (row, s1), (col, s2) in coord_iterator:
            d = levenshtein_dist(s1, s2)
            if d <= self.cutoff:
                result.append((d + 1, origin_row + row, origin_col + col))

As such, I replicated it for the Hamming distance plus sequence length, and added references to it wherever Levenshtein cropped up:

        result = []
        for (row, s1), (col, s2) in coord_iterator:

            # require identical length of sequences
            if len(s1) != len(s2):
                continue
            d = hamming_dist(s1, s2)
            if d <= self.cutoff:
                result.append((d + 1, origin_row + row, origin_col + col))

Good news is this seems to work, kind of. It produces a graph and everything, and the graph balls seem sensible, but they also appear to have no edges.

![image](https://user-images.githubusercontent.com/14993986/100659938-3df49380-3349-11eb-9449-9558480b3105.png)

Also, for whatever reason, it takes longer to run than the Levenshtein, with higher process count numbers during the progress bars. This seems weird, as if anything you'd imagine the metric would be more discerning?

```
100%|██████████| 561/561 [00:01<00:00, 313.37it/s]
100%|██████████| 990/990 [00:03<00:00, 320.64it/s]
100%|██████████| 14098/14098 [00:00<00:00, 55333.33it/s]
100%|██████████| 22884/22884 [00:00<00:00, 47773.14it/s]
100%|██████████| 122761/122761 [00:01<00:00, 105207.93it/s]
... storing 'ct_cluster_nt_levenshtein' as categorical
```

```
100%|██████████| 561/561 [00:02<00:00, 196.40it/s]
100%|██████████| 990/990 [00:04<00:00, 206.99it/s]
100%|██████████| 218911/218911 [00:04<00:00, 52849.82it/s]
100%|██████████| 406018/406018 [00:08<00:00, 47138.79it/s]
100%|██████████| 1903399/1903399 [00:17<00:00, 106348.03it/s]
... storing 'ct_cluster_nt_hamming-substitution' as categorical
```

Maybe my attempt at an implementation will be of use, maybe it won't. The general idea still stands - a neighbour graph that requires sequence length identity and then computes Hamming is immunologist-blessed for BCR processing, and would be nice as an option.