### PR TITLE
Include Python 3.9 in tests. Drop support for 3.6.

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,14 +18,14 @@ requirements:
   # The way the version is resolved from SCM (flit + get_version)
   # requires all dependencies to be installed at build time.
   host:
-    - python >=3.6
+    - python >=3.7
     - flit
     - setuptools_scm
     - pytoml
     - importlib_metadata
 
   run:
-    - python >=3.6
+    - python >=3.7
     - anndata >=0.7.3
     - scanpy>=1.5.1
     - pandas>=0.21

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: ["ubuntu-latest", "macos-latest"]
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install flit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,12 @@ Scirpy: A Scanpy extension for analyzing single-cell immune-cell receptor sequen
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
     :alt: The uncompromising python formatter
-    
+
 .. |airr| image:: https://img.shields.io/static/v1?label=AIRR-C%20sw-tools%20v1&message=compliant&color=008AFF&labelColor=000000&style=flat)
     :target: https://docs.airr-community.org/en/stable/swtools/airr_swtools_standard.html
     :alt: AIRR-compliant
 
-Scirpy is a scalable python-toolkit to analyse T cell receptor (TCR) or B cell receptor (BCR) 
+Scirpy is a scalable python-toolkit to analyse T cell receptor (TCR) or B cell receptor (BCR)
 repertoires from single-cell RNA sequencing (scRNA-seq) data. It seamlessly integrates with the popular
 `scanpy <https://scanpy.readthedocs.io/en/stable/index.html>`_ library and
 provides various modules for data import, analysis and visualization.
@@ -50,7 +50,7 @@ The case study from our preprint is available `here <https://icbi-lab.github.io/
 
 Installation
 ^^^^^^^^^^^^
-You need to have Python 3.6 or newer installed on your system. If you don't have
+You need to have Python 3.7 or newer installed on your system. If you don't have
 Python installed, we recommend installing `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 
 There are several alternative options to install scirpy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: R'
 ]
-requires-python = '>= 3.6'
+requires-python = '>= 3.7'
 requires = [
     'anndata>=0.7.3',
     'scanpy>=1.6.0',


### PR DESCRIPTION
Closes #228 