### PR TITLE
Fix #268

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test = [
     'black'
 ]
 dandelion = [
-    'sc-dandelion',
+    'sc-dandelion>=0.1.3',
     'adjusttext', # see https://github.com/zktuong/dandelion/issues/55
 ]
 doc = [

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -109,7 +109,7 @@ class AirrCell(MutableMapping):
             v = _is_true2(v)
         try:
             existing_value = self._cell_attrs[k]
-            if existing_value != v:
+            if existing_value != v and not _is_na2(existing_value):
                 raise ValueError(
                     "Cell-level attributes differ between different chains. "
                     f"Already present: `{existing_value}`. Tried to add `{v}`."

--- a/scirpy/io/_io.py
+++ b/scirpy/io/_io.py
@@ -654,7 +654,6 @@ def to_dandelion(adata: AnnData):
                     "sequence_id": f"{tmp_cell.cell_id}_contig_{i}",
                 }
             )
-            chain["umi_count"] = chain.pop("duplicate_count")
             contig_dicts[chain["sequence_id"]] = chain
 
     data = pd.DataFrame.from_dict(contig_dicts, orient="index")


### PR DESCRIPTION
Allow "None" values to be present as cell-level attributes
during `merge_airr_chains`.