### PR TITLE
Fix #270

### DIFF
--- a/scirpy/_tools/_clonotypes.py
+++ b/scirpy/_tools/_clonotypes.py
@@ -288,7 +288,7 @@ def define_clonotype_clusters(
     # clonotype cluster = graph partition
     idx, values = zip(
         *itertools.chain.from_iterable(
-            zip(ctn.cell_indices[ct_id], itertools.repeat(str(clonotype_cluster)))
+            zip(ctn.cell_indices[str(ct_id)], itertools.repeat(str(clonotype_cluster)))
             for ct_id, clonotype_cluster in enumerate(part.membership)
         )
     )
@@ -543,7 +543,7 @@ def clonotype_network(
     # Expand to cell coordinates to store in adata.obsm
     idx, coords = zip(
         *itertools.chain.from_iterable(
-            zip(clonotype_res["cell_indices"][node_id], itertools.repeat(coord))
+            zip(clonotype_res["cell_indices"][str(node_id)], itertools.repeat(coord))
             for node_id, coord in zip(graph.vs["node_id"], coords)  # type: ignore
         )
     )
@@ -597,8 +597,8 @@ def _graph_from_coordinates(
     )
 
     # Networkx graph object for plotting edges
-    adj_mat = clonotype_res["distances"][coords["dist_idx"].values, :][
-        :, coords["dist_idx"].values
+    adj_mat = clonotype_res["distances"][coords["dist_idx"].values.astype(int), :][
+        :, coords["dist_idx"].values.astype(int)
     ]
 
     return coords, adj_mat

--- a/scirpy/ir_dist/_clonotype_neighbors.py
+++ b/scirpy/ir_dist/_clonotype_neighbors.py
@@ -99,8 +99,10 @@ class ClonotypeNeighbors:
         # It doesn't necessarily have the same order as `clonotypes`.
         # This needs to be a dict of arrays, otherwiswe anndata
         # can't save it to h5ad.
+        # Also the dict keys need to be of type `str`, or they'll get converted
+        # implicitly.
         self.cell_indices = {
-            i: obs_filtered.index[
+            str(i): obs_filtered.index[
                 clonotype_groupby.indices.get(
                     # indices is not a tuple if it's just a single column.
                     ct_tuple[0] if len(ct_tuple) == 1 else ct_tuple,

--- a/scirpy/tests/test_workflow.py
+++ b/scirpy/tests/test_workflow.py
@@ -44,9 +44,8 @@ def test_workflow(
         """If save_intermediates is True, save the anndata to a temporary location
         and re-load it from disk."""
         if save_intermediates:
-            with tempfile.NamedTemporaryFile() as f:
-                adata.write_h5ad(f.name)
-                return sc.read_h5ad(f.name)
+            adata.write_h5ad(tmp_path / "tmp_adata.h5ad")
+            return sc.read_h5ad(tmp_path / "tmp_adata.h5ad")
         else:
             return adata
 


### PR DESCRIPTION
Store dict keys of `adata.uns[clonotype_key]["cell_indicies"]
as strs instead of ints. h5py will convert them to strs anyway
and previously broke functions after loading a anndata object
from disk.