### PR TITLE
adjusting add_serialized_chains behaviour

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -411,12 +411,12 @@
 }
 
 @article{Stephenson2021,
-  doi       = {10.1101/2021.01.13.21249725},
-  url       = {https://doi.org/10.1101/2021.01.13.21249725},
+  doi       = {10.1038/s41591-021-01329-2},
+  url       = {https://www.nature.com/articles/s41591-021-01329-2},
   year      = {2021},
-  month     = jan,
-  publisher = {Cold Spring Harbor Laboratory},
+  month     = apr,
+  publisher = {Springer Science and Business Media {LLC}},
   author    = {Emily Stephenson and Gary Reynolds and Rachel A Botting and Fernando J Calero-Nieto and Michael Morgan and Zewen Kelvin Tuong and Karsten Bach and Waradon Sungnak and Kaylee B Worlock and Masahiro Yoshida and Natsuhiko Kumasaka and Katarzyna Kania and Justin Engelbert and Bayanne Olabi and Jarmila Stremenova Spegarova and Nicola K Wilson and Nicole Mende and Laura Jardine and Louis CS Gardner and Issac Goh and Dave Horsfall and Jim McGrath and Simone Webb and Michael W. Mather and Rik GH Lindeboom and Emma Dann and Ni Huang and Krzysztof Polanski and Elena Prigmore and Florian Gothe and Jonathan Scott and Rebecca P Payne and Kenneth F Baker and Aidan T Hanrath and Ina CD Schim van der Loeff and Andrew S Barr and Amada Sanchez-Gonzalez and Laura Bergamaschi and Federica Mescia and Josephine L Barnes and Eliz Kilich and Angus de Wilton and Anita Saigal and Aarash Saleh and Sam M Janes and Claire M Smith and Nusayhah Gopee and Caroline Wilson and Paul Coupland and Jonathan M Coxhead and Vladimir Y Kiselev and Stijn van Dongen and Jaume Bacardit and Hamish W King and Anthony J Rostron and A John Simpson and Sophie Hambleton and Elisa Laurenti and Paul A Lyons and Kerstin B Meyer and Marko Z Nikolic and Christopher JA Duncan and Ken Smith and Sarah A Teichmann and Menna R Clatworthy and John C Marioni and Berthold Gottgens and Muzlifah Haniffa and},
-  title     = {The cellular immune response to {COVID}-19 deciphered by single cell multi-omics across three {UK} centres},
-  journal   = {BioRxiv}
+  title     = {Single-cell multi-omics analysis of the immune response in {COVID}-19},
+  journal   = {Nature Medicine}
 }

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -163,8 +163,6 @@ class AirrCell(MutableMapping):
         if not _is_na2(serialized_chains):
             tmp_chains = json.loads(serialized_chains)
             for chain in tmp_chains:
-                # keep only keys present in _chain_fields
-                # chain = {k: v for k, v in chain.items() if k in self._chain_fields}
                 self.add_chain(chain)
 
     def _split_chains(self) -> Tuple[bool, dict]:

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -163,6 +163,8 @@ class AirrCell(MutableMapping):
         if not _is_na2(serialized_chains):
             tmp_chains = json.loads(serialized_chains)
             for chain in tmp_chains:
+                # keep only keys present in _chain_fields
+                # chain = {k: v for k, v in chain.items() if k in self._chain_fields}
                 self.add_chain(chain)
 
     def _split_chains(self) -> Tuple[bool, dict]:

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -163,7 +163,9 @@ class AirrCell(MutableMapping):
         if not _is_na2(serialized_chains):
             tmp_chains = json.loads(serialized_chains)
             for chain in tmp_chains:
-                self.add_chain(chain)
+                tmp_chain = AirrCell.empty_chain_dict()
+                tmp_chain.update(chain)
+                self.add_chain(tmp_chain)
 
     def _split_chains(self) -> Tuple[bool, dict]:
         """

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -236,7 +236,9 @@ class AirrCell(MutableMapping):
         return tuple(-1 if x is None else x for x in sort_tuple)
 
     @staticmethod
-    def _serialize_chains(chains: List[MutableMapping], include_fields: Optional[Collection[str]] = None) -> str:
+    def _serialize_chains(
+        chains: List[MutableMapping], include_fields: Optional[Collection[str]] = None
+    ) -> str:
         """Serialize chains into a JSON object. This is useful for storing
         an arbitrary number of extra chains in a single column of a dataframe."""
         # convert numpy dtypes to python types
@@ -303,7 +305,9 @@ class AirrCell(MutableMapping):
         include_fields.add("cell_id")
 
         res_dict["multi_chain"], chain_dict = self._split_chains()
-        res_dict["extra_chains"] = self._serialize_chains(chain_dict.pop("extra"), include_fields = include_fields)
+        res_dict["extra_chains"] = self._serialize_chains(
+            chain_dict.pop("extra"), include_fields=include_fields
+        )
 
         # add cell-level attributes
         for key in self:

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -251,8 +251,6 @@ class AirrCell(MutableMapping):
                             chain[k] = chain[k].item()
                         except AttributeError:
                             pass
-                    else:
-                        pass
                 else:
                     try:
                         chain[k] = chain[k].item()

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -163,6 +163,8 @@ class AirrCell(MutableMapping):
         if not _is_na2(serialized_chains):
             tmp_chains = json.loads(serialized_chains)
             for chain in tmp_chains:
+                # keep only keys present in _chain_fields
+                chain = {k: v for k, v in chain.items() if k in self._chain_fields}
                 self.add_chain(chain)
 
     def _split_chains(self) -> Tuple[bool, dict]:

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -243,18 +243,17 @@ class AirrCell(MutableMapping):
         # https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types
         for chain in chains:
             for k, v in chain.items():
-                if include_fields is not None:
-                    if k in include_fields:
-                        try:
-                            chain[k] = chain[k].item()
-                        except AttributeError:
-                            pass
-                else:
-                    try:
-                        chain[k] = chain[k].item()
-                    except AttributeError:
-                        pass
-        return json.dumps(chains)
+                try:
+                    chain[k] = chain[k].item()
+                except AttributeError:
+                    pass
+
+        # Filter chains for `include_fields`
+        chains_filtered = [
+            {k: v for k, v in chain.items() if k in include_fields} for chain in chains
+        ]
+
+        return json.dumps(chains_filtered)
 
     def to_airr_records(self) -> Iterable[dict]:
         """Iterate over chains as AIRR-Rearrangent compliant dictonaries.

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -164,7 +164,7 @@ class AirrCell(MutableMapping):
             tmp_chains = json.loads(serialized_chains)
             for chain in tmp_chains:
                 # keep only keys present in _chain_fields
-                chain = {k: v for k, v in chain.items() if k in self._chain_fields}
+                # chain = {k: v for k, v in chain.items() if k in self._chain_fields}
                 self.add_chain(chain)
 
     def _split_chains(self) -> Tuple[bool, dict]:

--- a/scirpy/io/_io.py
+++ b/scirpy/io/_io.py
@@ -663,7 +663,9 @@ def to_dandelion(adata: AnnData):
 
 
 @_doc_params(doc_working_model=doc_working_model)
-def from_dandelion(dandelion, transfer=False) -> AnnData:
+def from_dandelion(
+    dandelion, transfer: bool = False, include_fields: Optional[Collection[str]] = None
+) -> AnnData:
     """\
     Import data from `Dandelion <https://github.com/zktuong/dandelion>`_ (:cite:`Stephenson2021`).
 
@@ -691,7 +693,14 @@ def from_dandelion(dandelion, transfer=False) -> AnnData:
     for col in dandelion_df.columns:
         dandelion_df.loc[dandelion_df[col] == "unassigned", col] = None
 
-    adata = read_airr(dandelion_df)
+    if include_fields is None:
+        if RearrangementSchema.validate_header(dandelion_df.columns):
+            adata = read_airr(dandelion_df, include_fields=None)
+        else:
+            adata = read_airr(dandelion_df)
+    else:
+        adata = read_airr(dandelion_df, include_fields=include_fields)
+
     if transfer:
         ddl.tl.transfer(
             adata, dandelion

--- a/scirpy/io/_io.py
+++ b/scirpy/io/_io.py
@@ -667,6 +667,8 @@ def from_dandelion(dandelion, transfer: bool = False, **kwargs) -> AnnData:
     """\
     Import data from `Dandelion <https://github.com/zktuong/dandelion>`_ (:cite:`Stephenson2021`).
 
+    Internally calls :func:`scirpy.io.read_airr`. 
+
     {doc_working_model}
 
     Parameters
@@ -676,6 +678,8 @@ def from_dandelion(dandelion, transfer: bool = False, **kwargs) -> AnnData:
     transfer
         Whether to execute `dandelion.tl.transfer` to transfer all data
         to the :class:`anndata.AnnData` instance.
+    **kwargs
+        Additional arguments passed to :func:`scirpy.io.read_airr`. 
 
     Returns
     -------

--- a/scirpy/io/_io.py
+++ b/scirpy/io/_io.py
@@ -663,9 +663,7 @@ def to_dandelion(adata: AnnData):
 
 
 @_doc_params(doc_working_model=doc_working_model)
-def from_dandelion(
-    dandelion, transfer: bool = False, include_fields: Optional[Collection[str]] = None
-) -> AnnData:
+def from_dandelion(dandelion, transfer: bool = False, **kwargs) -> AnnData:
     """\
     Import data from `Dandelion <https://github.com/zktuong/dandelion>`_ (:cite:`Stephenson2021`).
 
@@ -693,13 +691,7 @@ def from_dandelion(
     for col in dandelion_df.columns:
         dandelion_df.loc[dandelion_df[col] == "unassigned", col] = None
 
-    if include_fields is None:
-        if RearrangementSchema.validate_header(dandelion_df.columns):
-            adata = read_airr(dandelion_df, include_fields=None)
-        else:
-            adata = read_airr(dandelion_df)
-    else:
-        adata = read_airr(dandelion_df, include_fields=include_fields)
+    adata = read_airr(dandelion_df, **kwargs)
 
     if transfer:
         ddl.tl.transfer(


### PR DESCRIPTION
Hi @grst,

I'm adding some updates to dandelion's parser and came across a small issue and wondering if you could give me a hand.
I've made a small snippet of the all_contig_annotations.json file from 10x's resource to use as a fixture (attached as 'data.txt' here because github doesn't allow me to attach with .json extension):
[data.txt](https://github.com/icbi-lab/scirpy/files/6823960/data.txt)


The following round tripping works:
```python
import dandelion as ddl
import scirpy as ir

adata = ir.io.read_10x_vdj('data.json')
vdj = ddl.read_10x_vdj('data.json') # I've wrote a new parser for dandelion

vdj_1 = ir.io.to_dandelion(adata)
adata_1 = ddl.to_scirpy(vdj) # this basically calls ir.io.from_dandelion

adata_2 = ir.io.from_dandelion(vdj)
vdj_2 = ddl.from_scirpy(adata) # this basically calls ir.io.to_dandelion
```

And while this works:
```python
adata_3 = ddl.to_scirpy(vdj_2)
```

the following doesn't:
```python
vdj_3 = ddl.from_scirpy(adata_3)
adata_4 = ir.io.to_dandelion(adata_2)
```

Both come up with the same issue:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-15-00d75a1a5f48> in <module>
     26     try:
     27         print(row['extra_chains'])
---> 28         tmp_ir_cell.add_serialized_chains(row["extra_chains"])
     29     except KeyError:
     30         print(row['extra_chains'])

~/Documents/Github/scirpy/scirpy/io/_datastructures.py in add_serialized_chains(self, serialized_chains)
    164             tmp_chains = json.loads(serialized_chains)
    165             for chain in tmp_chains:
--> 166                 self.add_chain(chain)
    167 
    168     def _split_chains(self) -> Tuple[bool, dict]:

~/Documents/Github/scirpy/scirpy/io/_datastructures.py in add_chain(self, chain)
    144             self._chain_fields = list(chain.keys())
    145         elif self._chain_fields != list(chain.keys()):
--> 146             raise ValueError("All chains must have the same fields!")
    147 
    148         if "locus" not in chain:

ValueError: All chains must have the same fields!
```

If I add `print(tmp_chain)` in the loop before `self.add_serialized_chains`, the output is this:
```python
{'sequence_id': None, 'sequence': None, 'rev_comp': None, 'productive': 'True', 'v_call': 'IGLV3-1', 'd_call': nan, 'j_call': 'IGLJ2', 'sequence_alignment': None, 'germline_alignment': None, 'junction': 'TGTCAGGCGTGGGACAGCAGCACTGTGGTATTC', 'junction_aa': 'CQAWDSSTVVF', 'v_cigar': None, 'd_cigar': None, 'j_cigar': None, 'c_call': 'IGLC2', 'consensus_count': 464.0, 'duplicate_count': 16.0, 'locus': 'IGL'}
{'sequence_id': None, 'sequence': None, 'rev_comp': None, 'productive': 'None', 'v_call': nan, 'd_call': nan, 'j_call': nan, 'sequence_alignment': None, 'germline_alignment': None, 'junction': nan, 'junction_aa': nan, 'v_cigar': None, 'd_cigar': None, 'j_cigar': None, 'c_call': nan, 'consensus_count': nan, 'duplicate_count': nan, 'locus': nan}
{'sequence_id': None, 'sequence': None, 'rev_comp': None, 'productive': 'True', 'v_call': 'IGHV4-39', 'd_call': 'IGHD3-22', 'j_call': 'IGHJ4', 'sequence_alignment': None, 'germline_alignment': None, 'junction': 'TGTGCGGTCCAGTATTACTATGATAGTAGTGGTTACCGGAGAACTGAGGTGCCCTTTGACTACTGG', 'junction_aa': 'CAVQYYYDSSGYRRTEVPFDYW', 'v_cigar': None, 'd_cigar': None, 'j_cigar': None, 'c_call': 'IGHM', 'consensus_count': 488.0, 'duplicate_count': 30.0, 'locus': 'IGH'}
{'sequence_id': None, 'sequence': None, 'rev_comp': None, 'productive': 'None', 'v_call': nan, 'd_call': nan, 'j_call': nan, 'sequence_alignment': None, 'germline_alignment': None, 'junction': nan, 'junction_aa': nan, 'v_cigar': None, 'd_cigar': None, 'j_cigar': None, 'c_call': nan, 'consensus_count': nan, 'duplicate_count': nan, 'locus': nan}
```

Looking at the json serialised entries in `extra_chains`:
```python
import json
json.loads(row["extra_chains"])
[{'c_call': 'IGKC',
  'consensus_count': 120.0,
  'd_call': None,
  'd_cigar': None,
  'duplicate_count': 3.0,
  'germline_alignment': None,
  'j_call': 'IGKJ1',
  'j_cigar': None,
  'junction': None,
  'junction_aa': None,
  'locus': 'IGK',
  'np1_length': None,
  'np2_length': None,
  'productive': False,
  'rev_comp': None,
  'sequence': None,
  'sequence_alignment': None,
  'sequence_id': 'AAACCTGAGACTGTAA-1_contig_3',
  'v_call': None,
  'v_cigar': None}]
```

It looks like there a few additional keys (`np1_length` and `np2_length`). 

My proposed adjustments solves the round tripping issue but I wasn't sure if it was fitting with how the original class was supposed to function in situations like this were there's a mismatch in the type of fields present in the main chains vs extra chains.