### PR TITLE
Fix issues with AirrCell

### DIFF
--- a/scirpy/_preprocessing/_merge_adata.py
+++ b/scirpy/_preprocessing/_merge_adata.py
@@ -52,7 +52,9 @@ def merge_airr_chains(adata: AnnData, adata2: AnnData) -> None:
             tmp_cell = cell_dict[cell.cell_id]
             # this is a legacy operation. With adatas generated with scirpy
             # >= 0.7 this isn't necessary anymore, as all chains are preserved.
-            tmp_cell["multi_chain"] |= cell["multi_chain"]
+            tmp_cell["multi_chain"] = bool(tmp_cell["multi_chain"]) | bool(
+                cell["multi_chain"]
+            )
             for tmp_chain in cell.chains:
                 tmp_cell.add_chain(tmp_chain)
             # add cell-level attributes

--- a/scirpy/io/_datastructures.py
+++ b/scirpy/io/_datastructures.py
@@ -70,7 +70,7 @@ class AirrCell(MutableMapping):
         self._chains = list()
         self["cell_id"] = cell_id
         # legacy argument for the old AnnData scheme (when there was no `extra_chains` field)
-        self["multi_chain"] = False
+        self._cell_attrs["multi_chain"] = None
 
     def __repr__(self):
         return "AirrCell {} with {} chains".format(self.cell_id, len(self.chains))
@@ -301,15 +301,17 @@ class AirrCell(MutableMapping):
         include_fields = set(include_fields)
         include_fields.add("cell_id")
 
-        res_dict["multi_chain"], chain_dict = self._split_chains()
-        res_dict["extra_chains"] = self._serialize_chains(
-            chain_dict.pop("extra"), include_fields=include_fields
-        )
-
         # add cell-level attributes
         for key in self:
             if key in include_fields:
                 res_dict[key] = self[key]
+
+        # this will overwrite the fields, should the already be included as cell-level
+        # attributes.
+        res_dict["multi_chain"], chain_dict = self._split_chains()
+        res_dict["extra_chains"] = self._serialize_chains(
+            chain_dict.pop("extra"), include_fields=include_fields
+        )
 
         # add chain-level attributes, do nothing when cell with no chains
         if self._chain_fields is not None:


### PR DESCRIPTION
1. When include_fields=None, the multi_chain value has not been
   transferred properly to adata.obs, as it had been overwritten.
   Rearranged the order of statements to fix it. This prevented
   bug 2 to surface.
2. Empty Airr cells got initialized with multi_chain=False. This
   led to a conflict due to 'inconsistent cell-level attributes'
   as soon as chains got added, even if all added chains correctly
   had multi_chain=True. Now set it to None initially, as None
   gets ignored when merging cell-level attributes.
